### PR TITLE
Gb/cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# test files
+./ksqljsTest.js

--- a/__tests__/builderTest.js
+++ b/__tests__/builderTest.js
@@ -1,5 +1,6 @@
 const queryBuilder = require('../ksqljs/queryBuilder.js');
 
+
 describe('Unit tests for query builder class', () => {
   let builder;
   let query;

--- a/__tests__/integrationtests.js
+++ b/__tests__/integrationtests.js
@@ -6,165 +6,180 @@ server using the command 'docker compose-up'. This will spin up a ksqlDB server 
 'http://localhost:8088'
 */
 
-describe('Integration Tests', () => {
-  beforeAll((done) => {
-    client = new ksqljs({ ksqldbURL: 'http://localhost:8088' });
-    done();
-  });
 
-  afterAll(async () => {
-    await client.ksql('DROP STREAM IF EXISTS TESTSTREAM2;');
-    await client.ksql('DROP STREAM IF EXISTS TESTJESTSTREAM DELETE TOPIC;');
-  })
-
-  it('properly creates a stream', async () => {
-    await client.createStream('TESTJESTSTREAM', ['name VARCHAR', 'email varchar', 'age INTEGER'], 'testJestTopic', 'json', 1);
-    const streams = await client.ksql('LIST STREAMS;');
-    const allStreams = streams.streams;
-    let streamExists = false;
-    for (let i = 0; i < allStreams.length; i++) {
-      if (allStreams[i].name === "TESTJESTSTREAM") {
-        streamExists = true;
-        break;
-      }
-    }
-    expect(streamExists).toEqual(true);
-  })
-
-  it('properly creates a push query', () => {
-    let pushActive = false;
-    client.push('SELECT * FROM TESTJESTSTREAM EMIT CHANGES LIMIT 1;', async (data) => {
-      if (JSON.parse(data).queryId) {
-        pushActive = true;
-      }
-      expect(pushActive).toEqual(true)
+describe('--Integration Tests--', () => {
+  describe('--Method Tests--', () => {
+    beforeAll((done) => {
+      client = new ksqljs({ ksqldbURL: 'http://localhost:8088' });
+      done();
     });
-  })
-
-  it('properly terminates a push query', () => {
-    client.push('SELECT * FROM TESTJESTSTREAM EMIT CHANGES LIMIT 3;', async (data) => {
-      const terminateRes = await client.terminate(JSON.parse(data).queryId);
-      expect(terminateRes.wasTerminated).toEqual(true);
+    afterAll(async () => {
+      await client.ksql('DROP STREAM IF EXISTS TESTJESTSTREAM DELETE TOPIC;');
     })
-  })
-
-  it('properly inserts a row into a stream', async () => {
-    await client.insertStream('TESTJESTSTREAM', [
-      { "name": "stab-rabbit", "email": "123@mail.com", "age": 100 }
-    ]);
-    const data = [];
-    await client.push('SELECT * FROM TESTJESTSTREAM;', async (chunk) => {
-      data.push(JSON.parse(chunk));
-      if (data[1]) {
-        client.terminate(data[0].queryId);
-        expect(data[1]).toEqual(["stab-rabbit", "123@mail.com", 100])
+    it('.createStream properly creates a stream', async () => {
+      const result = await client.createStream('TESTJESTSTREAM', ['name VARCHAR', 'email varchar', 'age INTEGER'], 'testJestTopic', 'json', 1);
+      const streams = await client.ksql('LIST STREAMS;');
+      const allStreams = streams.streams;
+      let streamExists = false;
+      for (let i = 0; i < allStreams.length; i++) {
+        if (allStreams[i].name === "TESTJESTSTREAM") {
+          streamExists = true;
+          break;
+        }
       }
-    });
-  })
+      expect(streamExists).toEqual(true);
+    })
 
-  it('receives the correct data from a pull query', async () => {
-    const pullData = await client.pull("SELECT * FROM TESTJESTSTREAM;");
-    expect(pullData[1]).toEqual(['stab-rabbit', '123@mail.com', 100]);
-  })
+    it('.push properly creates a push query', () => {
+      let pushActive = false;
+      client.push('SELECT * FROM TESTJESTSTREAM EMIT CHANGES LIMIT 1;', async (data) => {
+        if (JSON.parse(data).queryId) {
+          pushActive = true;
+        }
+        expect(pushActive).toEqual(true)
+      });
+    })
 
-
-  it('inspectQueryStatus checks if a stream is created successfully', async () => {
-    const streamName = 'TESTSTREAM2'
-    const create = await client.ksql(`CREATE STREAM IF NOT EXISTS ${streamName}
-                    (name VARCHAR,
-                    email varchar,
-                    age INTEGER)
-                 WITH (
-                     KAFKA_TOPIC = 'testJestTopic',
-                     VALUE_FORMAT = 'json',
-                     PARTITIONS = 1
-                 );`);
-    const commandId = create ? create.commandId : `stream/${streamName}/create`;
-    const status = await client.inspectQueryStatus(commandId);
-    // response should be { status: 'SUCCESS', message: 'Stream created', queryId: null }
-    expect(status.data).toEqual(expect.objectContaining({
-      status: expect.any(String),
-      message: expect.any(String),
-      queryId: null
-    }));
-  })
-
-  it('inspectServerInfo returns the server info and status', async () => {
-    const status = await client.inspectServerInfo();
-    // should return something like: {
-    //   KsqlServerInfo: {
-    //     version: '0.25.1',
-    //     kafkaClusterId: '0Yxd6N5OSKGDUalltPWvXg',
-    //     ksqlServiceId: 'default_',
-    //     serverStatus: 'RUNNING'
-    //   }
-    // }
-    expect(status.data).toEqual(expect.objectContaining({
-      KsqlServerInfo: expect.objectContaining({
-        version: expect.any(String),
-        kafkaClusterId: expect.any(String),
-        serverStatus: expect.any(String)
-      })
-    }));
-  })
-
-  it('inspectServerHealth returns the server health', async () => {
-    const status = await client.inspectServerHealth();
-    // should return something like: {
-    //   isHealthy: true,
-    //   details: {
-    //     metastore: { isHealthy: true },
-    //     kafka: { isHealthy: true },
-    //     commandRunner: { isHealthy: true }
-    //   }
-    // }
-    expect(status.data).toEqual(expect.objectContaining({
-      isHealthy: expect.any(Boolean),
-      details: expect.objectContaining({
-        metastore: expect.anything(),
-        kafka: expect.anything(),
-        commandRunner: expect.anything()
+    it('.terminate properly terminates a push query', () => {
+      client.push('SELECT * FROM TESTJESTSTREAM EMIT CHANGES LIMIT 3;', async (data) => {
+        const terminateRes = await client.terminate(JSON.parse(data).queryId);
+        expect(terminateRes.wasTerminated).toEqual(true);
       })
     })
-    );
-  })
 
-  it('inspectClusterStatus returns the cluster status', async () => {
-    const status = await client.inspectClusterStatus();
-    // should return something like: {
-    //   clusterStatus: {
-    //     'ksqldb-server:8088': {
-    //       hostAlive: true,
-    //       lastStatusUpdateMs: 1653164479237,
-    //       activeStandbyPerQuery: [Object],
-    //       hostStoreLags: [Object]
-    //     }
-    //   }}
-    expect(status.data).toEqual(expect.objectContaining({
-      clusterStatus: expect.anything()
+    it('.insertStream properly inserts a row into a stream', async () => {
+      const response = await client.insertStream('TESTJESTSTREAM', [
+        { "name": "stab-rabbit", "email": "123@mail.com", "age": 100 }
+      ]);
+      console.log(response);
+      const data = [];
+      await client.push('SELECT * FROM TESTJESTSTREAM EMIT CHANGES;', async (chunk) => {
+        data.push(JSON.parse(chunk));
+        if (data[1]) {
+          client.terminate(data[0].queryId);
+          expect(data[1]).toEqual(["stab-rabbit", "123@mail.com", 100])
+        }
+      });
     })
-    );
+
+    it('.pull receives the correct data from a pull query', async () => {
+      const pullData = await client.pull("SELECT * FROM TESTJESTSTREAM;");
+      expect(pullData[1]).toEqual(['stab-rabbit', '123@mail.com', 100]);
+    })
+    it('.pullFromTo receives all the data', async () => {
+      const pullData = await client.pull("SELECT * FROM TESTJESTSTREAM;");
+      const data = await client.pullFromTo('TESTJESTSTREAM', 'America/Los_Angeles', ['2022-01-01', '00', '00', '00']);
+      const expectPullData = pullData[1];
+      const expectData = data[0].slice(0, 3);
+      expect(expectPullData).toEqual(expectData);
+    })
   })
+  describe('--Health Tests--', () => {
+    beforeAll((done) => {
+      client = new ksqljs({ ksqldbURL: 'http://localhost:8088' });
+      done();
+    });
 
-  it('isValidProperty returns true if a server configuration property is not prohibited from setting', async () => {
-    const status = await client.isValidProperty('test');
-    // should return true
-    expect(status.data).toEqual(true);
+    afterAll(async () => {
+      await client.ksql('DROP STREAM IF EXISTS TESTSTREAM2;');
+    })
+    it('.inspectQueryStatus checks if a stream is created successfully', async () => {
+      const streamName = 'TESTSTREAM2'
+      const create = await client.ksql(`CREATE STREAM IF NOT EXISTS ${streamName}
+                      (name VARCHAR,
+                      email varchar,
+                      age INTEGER)
+                   WITH (
+                       KAFKA_TOPIC = 'testJestTopic',
+                       VALUE_FORMAT = 'json',
+                       PARTITIONS = 1
+                   );`);
+      const commandId = create ? create.commandId : `stream/${streamName}/create`;
+      const status = await client.inspectQueryStatus(commandId);
+      // response should be { status: 'SUCCESS', message: 'Stream created', queryId: null }
+      expect(status.data).toEqual(expect.objectContaining({
+        status: expect.any(String),
+        message: expect.any(String),
+        queryId: null
+      }));
+    })
+
+    it('.inspectServerInfo returns the server info and status', async () => {
+      const status = await client.inspectServerInfo();
+      // should return something like: {
+      //   KsqlServerInfo: {
+      //     version: '0.25.1',
+      //     kafkaClusterId: '0Yxd6N5OSKGDUalltPWvXg',
+      //     ksqlServiceId: 'default_',
+      //     serverStatus: 'RUNNING'
+      //   }
+      // }
+      expect(status.data).toEqual(expect.objectContaining({
+        KsqlServerInfo: expect.objectContaining({
+          version: expect.any(String),
+          kafkaClusterId: expect.any(String),
+          serverStatus: expect.any(String)
+        })
+      }));
+    })
+
+    it('.inspectServerHealth returns the server health', async () => {
+      const status = await client.inspectServerHealth();
+      // should return something like: {
+      //   isHealthy: true,
+      //   details: {
+      //     metastore: { isHealthy: true },
+      //     kafka: { isHealthy: true },
+      //     commandRunner: { isHealthy: true }
+      //   }
+      // }
+      expect(status.data).toEqual(expect.objectContaining({
+        isHealthy: expect.any(Boolean),
+        details: expect.objectContaining({
+          metastore: expect.anything(),
+          kafka: expect.anything(),
+          commandRunner: expect.anything()
+        })
+      })
+      );
+    })
+
+    it('.inspectClusterStatus returns the cluster status', async () => {
+      const status = await client.inspectClusterStatus();
+      // should return something like: {
+      //   clusterStatus: {
+      //     'ksqldb-server:8088': {
+      //       hostAlive: true,
+      //       lastStatusUpdateMs: 1653164479237,
+      //       activeStandbyPerQuery: [Object],
+      //       hostStoreLags: [Object]
+      //     }
+      //   }}
+      expect(status.data).toEqual(expect.objectContaining({
+        clusterStatus: expect.anything()
+      })
+      );
+    })
+
+    it('.isValidProperty returns true if a server configuration property is not prohibited from setting', async () => {
+      const status = await client.isValidProperty('test');
+      // should return true
+      expect(status.data).toEqual(true);
+    })
+
+    // it('isValidProperty returns an error if the server property is prohibited from setting', async () => {
+    //   const status = await client.isValidProperty('ksql.connect.url');
+    //   // should return something like
+    //   // {
+    //   //   "@type": "generic_error",
+    //   //   "error_code": 40000,
+    //   //   "message": "One or more properties overrides set locally are prohibited by the KSQL server (use UNSET to reset their default value): [ksql.service.id]"
+    //   // }
+    //   expect(status.data).toEqual(expect.objectContaining({
+    //     type: expect.any(String),
+    //     error_code: expect.any(Number),
+    //     message: expect.any(String),
+    //   }));
+    // })
   })
-
-  // it('isValidProperty returns an error if the server property is prohibited from setting', async () => {
-  //   const status = await client.isValidProperty('ksql.connect.url');
-  //   // should return something like
-  //   // {
-  //   //   "@type": "generic_error",
-  //   //   "error_code": 40000,
-  //   //   "message": "One or more properties overrides set locally are prohibited by the KSQL server (use UNSET to reset their default value): [ksql.service.id]"
-  //   // }
-  //   expect(status.data).toEqual(expect.objectContaining({
-  //     type: expect.any(String),
-  //     error_code: expect.any(Number),
-  //     message: expect.any(String),
-  //   }));
-  // })
-
 })

--- a/__tests__/integrationtests.js
+++ b/__tests__/integrationtests.js
@@ -1,6 +1,10 @@
 const ksqljs = require('../ksqljs/ksqlJS.js');
 
 // Pre-requisite: start a docker container
+/* To add to README: Prior to running test with 'npm test', please start the ksqlDB
+server using the command 'docker compose-up'. This will spin up a ksqlDB server on
+'http://localhost:8088'
+*/
 
 describe('Integration Tests', () => {
   beforeAll((done) => {

--- a/ksqljs/customErrors.js
+++ b/ksqljs/customErrors.js
@@ -1,0 +1,55 @@
+/** This file contains custom Node.js errors that extends the built-in Error class
+ * REF: https://rclayton.silvrback.com/custom-errors-in-node-js
+ * REF: https://futurestud.io/tutorials/node-js-create-your-custom-error
+ */
+
+// used to wrap error received from ksqlDB server
+class ksqlDBError extends Error {
+  constructor(error) {
+    super(error.message)
+
+    // Ensure the name of this error is the same as the class name
+    this.name = this.constructor.name
+
+    // capturing the stack trace keeps the reference to your error class
+    Error.captureStackTrace(this, this.constructor);
+
+    // you may also assign additional properties to your error
+    //this.status = 404
+  }
+}
+
+// for returning error related to use of queryBuilder class
+class QueryBuilderError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = this.constructor.name
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+class EmptyQueryError extends QueryBuilderError {
+  constructor() {
+    super('Query should not be empty, undefined, or null');
+  }
+}
+
+class NumParamsError extends QueryBuilderError {
+  constructor(message) {
+    super(message);
+  }
+}
+
+class InappropriateStringParamError extends QueryBuilderError {
+  constructor(message) {
+    super(message);
+  }
+}
+
+module.exports = {
+  ksqlDBError,
+  QueryBuilderError,
+  EmptyQueryError,
+  NumParamsError,
+  InappropriateStringParamError
+};

--- a/ksqljs/ksqlJS.js
+++ b/ksqljs/ksqlJS.js
@@ -1,6 +1,7 @@
 const axios = require("axios");
 const http2 = require("http2");
 const { getPriority } = require("os");
+const { ksqlDBError } = require("./customErrors.js");
 const queryBuilder = require('./queryBuilder.js');
 const builder = new queryBuilder();
 
@@ -24,7 +25,10 @@ class ksqljs {
           // }
         })
       .then((res) => res.data)
-      .catch((error) => { throw error });
+      .catch((error) => {
+        console.error(error);
+        throw new ksqlDBError(error);
+      });
   }
 
   //---------------------Push queries (continue to receive updates to stream)-----------------
@@ -68,7 +72,10 @@ class ksqljs {
   terminate(queryId) {
     return axios.post(this.ksqldbURL + '/ksql', { ksql: `TERMINATE ${queryId};` })
       .then(res => res.data[0])
-      .catch(error => { return error });
+      .catch(error => {
+        console.error(error);
+        throw new ksqlDBError(error);
+      });
     // return new Promise((resolve, reject) => {
     // const session = http2.connect(this.ksqldbURL);
     // session.on("error", (err) => console.error(err));
@@ -99,7 +106,10 @@ class ksqljs {
   ksql(query) {
     return axios.post(this.ksqldbURL + '/ksql', { ksql: query })
       .then(res => res.data[0])
-      .catch(error => console.log(error));
+      .catch(error => {
+        console.error(error);
+        throw new ksqlDBError(error);
+      });
   }
 
   createStream(name, columnsType, topic, value_format = 'json', partitions = 1, key) {
@@ -112,7 +122,10 @@ class ksqljs {
 
     return axios.post(this.ksqldbURL + '/ksql', { ksql: query })
       .then(res => res)
-      .catch(error => console.log(error));
+      .catch(error => {
+        console.error(error);
+        throw new ksqlDBError(error);
+      });
   }
 
   //---------------------Create tables-----------------
@@ -121,7 +134,10 @@ class ksqljs {
     const query = `CREATE TABLE ${name} (${columnsTypeString}) WITH (kafka_topic='${topic}', value_format='${value_format}', partitions=${partitions});`
 
     axios.post(this.ksqldbURL + '/ksql', { ksql: query })
-      .catch(error => console.log(error));
+      .catch(error => {
+        console.error(error);
+        throw new ksqlDBError(error);
+      });
   }
 
   //---------------------Insert Rows Into Existing Streams-----------------
@@ -130,6 +146,8 @@ class ksqljs {
       const msgOutput = [];
 
       const session = http2.connect(this.ksqldbURL);
+      session.on("error", (err) => reject(err));
+
       const req = session.request({
         ":path": "/inserts-stream",
         ":method": "POST",
@@ -181,17 +199,21 @@ class ksqljs {
     return filtered;
   }
 
-  //---------------------Inspect push query status -----------------
-  // https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-rest-api/status-endpoint/
-  // @commandId - this id is obtained when using the .ksql method (/ksql endpoint)
-  //               to run CREATE, DROP, TERMINATE commands
-  // The returned JSON object has two properties:
-  // status (string): One of QUEUED, PARSING, EXECUTING, TERMINATED, SUCCESS, or ERROR.
-  // message (string): Detailed message regarding the status of the execution statement.
+  /** Inspects status of a push query status created with ksql method
+  @param - commanId is obtained when using the .ksql method (/ksql endpoint)
+                to run CREATE, DROP, TERMINATE commands
+  @return a JSON object with two properties:
+  - status (string): One of QUEUED, PARSING, EXECUTING, TERMINATED, SUCCESS, or ERROR.
+  - message (string): Detailed message regarding the status of the execution statement.
+  Ref: https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-rest-api/status-endpoint/
+  **/
   inspectQueryStatus(commandId) {
     return axios.get(this.ksqldbURL + `/status/${commandId}`)
       .then(response => response)
-      .catch(error => console.log(error));
+      .catch(error => {
+        console.error(error);
+        throw new ksqlDBError(error);
+      });
   }
 
 
@@ -202,7 +224,10 @@ class ksqljs {
   inspectServerInfo() {
     return axios.get(this.ksqldbURL + `/info`)
       .then(response => response)
-      .catch(error => console.log(error));
+      .catch(error => {
+        console.error(error);
+        throw new ksqlDBError(error);
+      });
   }
 
   /** Inspects server health
@@ -212,7 +237,10 @@ class ksqljs {
   inspectServerHealth() {
     return axios.get(this.ksqldbURL + `/healthcheck`)
       .then(response => response)
-      .catch(error => console.log(error));
+      .catch(error => {
+        console.error(error);
+        throw new ksqlDBError(error);
+      });
   }
 
 
@@ -223,7 +251,10 @@ class ksqljs {
   inspectClusterStatus() {
     return axios.get(this.ksqldbURL + `/clusterStatus`)
       .then(response => response)
-      .catch(error => console.log(error));
+      .catch(error => {
+        console.error(error);
+        throw new ksqlDBError(error);
+      });
   }
 
   /** Terminate a cluster and clean up resources
@@ -241,7 +272,10 @@ class ksqljs {
       }
     })
       .then(response => response)
-      .catch(error => console.log(error));
+      .catch(error => {
+        console.error(error);
+        throw new ksqlDBError(error);
+      });
   }
 
 
@@ -252,7 +286,10 @@ class ksqljs {
   isValidProperty(propertyName) {
     return axios.get(this.ksqldbURL + `/is_valid_property/${propertyName}`)
       .then(response => response)
-      .catch(error => console.log(error));
+      .catch(error => {
+        console.error(error);
+        throw new ksqlDBError(error);
+      });
   }
 };
 

--- a/ksqljs/ksqlJS.js
+++ b/ksqljs/ksqlJS.js
@@ -156,12 +156,12 @@ class ksqljs {
     })
   }
 
-  pullFromTo = async (streamName, timezone='Greenwich', from=[undefined, '00', '00', '00'], to=['2200-03-14', '00', '00', '00']) => {
-    if(!streamName || typeof timezone !== 'string' || !from 
-    || typeof from[0] !== 'string' || typeof from[1] !== 'string' || typeof from[2] !== 'string' || typeof from[3] !== 'string'  
-    || typeof to[0] !== 'string' || typeof to[1] !== 'string' || typeof to[2] !== 'string' || typeof to[3] !== 'string'  
-    || from[0].length !== 10 || to[0].length !== 10 || from[1].length !== 2 || to[1].length !== 2 || from[2].length !== 2 || to[2].length !== 2 || from[3].length !== 2 || to[3].length !== 2
-    ){
+  pullFromTo = async (streamName, timezone = 'Greenwich', from = [undefined, '00', '00', '00'], to = ['2200-03-14', '00', '00', '00']) => {
+    if (!streamName || typeof timezone !== 'string' || !from
+      || typeof from[0] !== 'string' || typeof from[1] !== 'string' || typeof from[2] !== 'string' || typeof from[3] !== 'string'
+      || typeof to[0] !== 'string' || typeof to[1] !== 'string' || typeof to[2] !== 'string' || typeof to[3] !== 'string'
+      || from[0].length !== 10 || to[0].length !== 10 || from[1].length !== 2 || to[1].length !== 2 || from[2].length !== 2 || to[2].length !== 2 || from[3].length !== 2 || to[3].length !== 2
+    ) {
       return new Error('invalid inputs');
     }
     const userFrom = `${from[0]}T${from[1]}:${from[2]}:${from[3]}`;
@@ -174,7 +174,7 @@ class ksqljs {
     console.log(data);
     const filtered = [];
     data.map((element) => {
-      if(element[element.length - 1] >= userFromUnix && element[element.length - 1] <= userToUnix){
+      if (element[element.length - 1] >= userFromUnix && element[element.length - 1] <= userToUnix) {
         filtered.push(element.slice(0, element.length - 1));
       }
     })
@@ -195,16 +195,20 @@ class ksqljs {
   }
 
 
-  //---------------------Inspect server status -----------------
-  // https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-rest-api/info-endpoint/
-  // The /info endpoint gives information about the version, clusterId and ksqlservice id.
-  // The /healthcheck gives the health status of the ksqlDB server.
+  /** Inspects server information such as version, cluster Id and ksqlservice id
+  @return an object with the server information
+  https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-rest-api/info-endpoint/
+  **/
   inspectServerInfo() {
     return axios.get(this.ksqldbURL + `/info`)
       .then(response => response)
       .catch(error => console.log(error));
   }
 
+  /** Inspects server health
+  @return an object with the server health
+  https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-rest-api/info-endpoint/
+  **/
   inspectServerHealth() {
     return axios.get(this.ksqldbURL + `/healthcheck`)
       .then(response => response)
@@ -212,19 +216,21 @@ class ksqljs {
   }
 
 
-  //---------------------Inspect cluster status -----------------
-  // https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-rest-api/cluster-status-endpoint/
-  // The /clusterStatus resource gives you information about the status of all ksqlDB servers in a ksqlDB cluster, which can be useful for troubleshooting
+  /** Inspect cluster status
+  @return an object with the status of all ksqlDB servers in a ksqlDB cluster, useful for troubleshooting
+  https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-rest-api/cluster-status-endpoint/
+  **/
   inspectClusterStatus() {
     return axios.get(this.ksqldbURL + `/clusterStatus`)
       .then(response => response)
       .catch(error => console.log(error));
   }
 
-  //---------------------Terminate cluster -----------------
-  // https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-rest-api/terminate-endpoint/
-  //  To terminate a ksqlDB cluster, first shut down all of the servers, except one.
-  // Then, send the TERMINATE CLUSTER request to the /ksql/terminate endpoint in the last remaining server.
+  /** Terminate a cluster and clean up resources
+  To terminate a ksqlDB cluster, first shut down all of the servers, except one.
+  Then, send the TERMINATE CLUSTER request to the /ksql/terminate endpoint in the last remaining server.
+  https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-rest-api/terminate-endpoint/
+  **/
   terminateCluster() {
     return axios.post(this.ksqldbURL + `/ksql/terminate`, {}, {
       headers: {
@@ -239,9 +245,10 @@ class ksqljs {
   }
 
 
-  //---------------------Get validity of a property -----------------
-  // https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-rest-api/is_valid_property-endpoint/
-  // The /is_valid_property resource tells you whether a property is prohibited from setting.
+  /** Tells us if a property is allowed to be set or changed
+  @return boolean
+  https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-rest-api/is_valid_property-endpoint/
+  **/
   isValidProperty(propertyName) {
     return axios.get(this.ksqldbURL + `/is_valid_property/${propertyName}`)
       .then(response => response)

--- a/ksqljs/queryBuilder.js
+++ b/ksqljs/queryBuilder.js
@@ -30,10 +30,13 @@ class queryBuilder {
       case "boolean":
         return param;
       case "object":
-        if (Array.isArray(param)){
+        if (Array.isArray(param)) {
           //check if spaces
-          if(param.includes(" ")){
+          if (param[0].includes(" ")) {
             return new Error("string params should not include spaces");
+          }
+          else if (param[0].includes(";")) {
+            return new Error("string params should not include semi-colons");
           }
           return `${param[0].replaceAll("'", "''")}`
         }


### PR DESCRIPTION
- created customError file
- refactored queryBuilder so errors are thrown instead of returned
- queryBuilder now throws an error if a semicolon is passed in a string param that is not wrapped in quotes
- refactored error handling in ksqlJS file - we now log the error and throw the error after wrapping it in a custom ksqlDBError 