### PR TITLE
Finished integrating initial collection of real-time line charts

### DIFF
--- a/ksqLight/public/main.js
+++ b/ksqLight/public/main.js
@@ -10,7 +10,11 @@ function createWindow () {
       enableRemoteModule: true,
     }
   })
-  win.loadURL("http://localhost:3000")
+
+  // open dev tools
+  win.webContents.openDevTools();
+
+  win.loadURL("http://localhost:3000");
 }
 
 app.on('ready', createWindow);

--- a/ksqLight/src/components/Homepage.js
+++ b/ksqLight/src/components/Homepage.js
@@ -2,20 +2,39 @@ import React from "react";
 import { useState } from "react";
 import { Typography, Grid, Toolbar } from "@mui/material";
 import { Chart } from "./Chart.js";
+import LineChart from "./LineChart.js";
 
 export const Homepage = () => {
   const [content, setContent] = useState('Chart placeholder');
+
+  const queryTypes = [
+    ["runningQueries", "Number of Running Queries"],
+    ["rebalancingQueries", "Number of Rebalancing Queries"],
+    ["pendingShutdownQueries", "Number of Pending Shutdown Queries"],
+    ["pendingErrorQueries", "Number of Pending Error Queries"],
+    ["numPersistentQueries", "Number of Persistent Queries"],
+    ["numIdleQueries", "Number of Idle Queries"],
+    ["numActiveQueries", "Number of Active Queries"],
+    ["notRunningQueries", "Number of Not Running Queries"],
+    ["messagesProducedPerSec", "Number of Messages Produced Per Second"],
+    ["messagesConsumedTotal", "Number of Messages Consumed"],
+    ["messagesConsumedPerSec", "Number of Messages Consumed Per Second"],
+    ["messagesConsumedMin", "Number of Messages Consumed Min"],
+    ["messagesConsumedMax", "Number of Messages Consumed Max"],
+    ["messagesConsumedAvg", "Number of Messages Consumed Average"],
+    ["livenessIndicator", "Liveness Indicator"],
+    ["errorRate", "Error Rate"],
+    ["errorQueries", "Number of Error Queries"],
+    ["createdQueries", "Number of Created Queries"],
+    ["bytesConsumedTotal", "Number of Bytes Consumed Total"],
+  ];
+
   return (
     <div>
       <Toolbar></Toolbar>
       <Typography color="primary">Homepage</Typography>
       <Grid container spacing={2} justifyContent="flex-start" alignItems="flex-start" sx={{ pl: 28 }}>
-        <Chart content={content}></Chart>
-        <Chart content={content}></Chart>
-        <Chart content={content}></Chart>
-        <Chart content={content}></Chart>
-        <Chart content={content}></Chart>
-        <Chart content={content}></Chart>
+        {queryTypes.map(([query, description], index) => <LineChart description={description} metric={query} key={index}/>)}
       </Grid>
     </div>
 

--- a/ksqLight/src/components/LineChart.js
+++ b/ksqLight/src/components/LineChart.js
@@ -1,0 +1,173 @@
+import React, { useEffect, useState } from "react";
+import { Grid, Typography } from "@mui/material";
+import {
+  ApolloClient,
+  InMemoryCache,
+  ApolloProvider,
+  gql,
+} from "@apollo/client";
+import Chart from "chart.js/auto";
+import ChartStreaming from "chartjs-plugin-streaming";
+import 'chartjs-adapter-moment';
+
+// import config from './chartConfig.js';
+
+
+Chart.register(ChartStreaming);
+
+const client = new ApolloClient({
+  uri: "http://localhost:5000/graphql",
+  cache: new InMemoryCache(),
+});
+
+//   console.log('test: ', Math.round(new Date().getTime() / 1000));
+
+export default function LineChart({ metric, description }) {
+  useEffect(() => {
+    let delayed;
+    // define chart context
+    const ctx = document.getElementById(metric).getContext("2d");
+
+    // define gradient for background
+    const gradient = ctx.createLinearGradient(0, 0, 0, 400);
+    gradient.addColorStop(0, 'rgba(58, 123, 213, 1)');
+    gradient.addColorStop(1, 'rgba(0, 210, 255, 0.3)')
+
+    // define chart configuration
+    const config = {
+    type: 'line',
+    data: {
+        datasets: [{
+        data: [],           // empty at the beginning,
+        borderColor: 'rgba(58, 123, 213, 1)',
+        pointRadius: 0,
+        hitRadius: 30,
+        hoverRadius: 5,
+        fill: true,
+        backgroundColor: gradient,
+      }]
+    },
+    options: {
+      responsive: true,
+      animation: {
+        onComplete: () => {
+          delayed = true;
+        },
+        // delay: (context) => {
+        //   let delay = 0;
+        //   if (context.type === "data" && context.mode === "default" && !delayed) {
+        //     delay = context.dataIndex * 300 + context.datasetIndex * 100;
+        //   }
+        //   return delay;
+        // }
+        delay: 3,
+      },
+      elements: {
+        line: {
+            tension: .4
+        }
+      },
+      scales: {
+        x: {
+          type: 'realtime',   // x axis will auto-scroll from right to left
+          realtime: {         // per-axis options
+            duration: 200000,  // data in the past 20000 ms will be displayed
+            refresh: 2000,    // onRefresh callback will be called every 1000 ms
+            delay: 2000,      // delay of 1000 ms, so upcoming values are known before plotting a line
+            pause: false,     // chart is not paused
+            ttl: undefined,   // data will be automatically deleted as it disappears off the chart
+            frameRate: 30,    // data points are drawn 30 times every second
+  
+            // a callback to update datasets
+            onRefresh: chart => {
+  
+              // query your data source and get the array of {x: timestamp, y: value} objects
+              client.query({
+                query: gql`
+                    query testQuery {
+                      ksqlDBMetrics(metric: "${metric}", resolution: 2, start: ${Math.round(new Date().getTime() / 1000) - 500}, end: ${Math.round(new Date().getTime() / 1000)}) {
+                            x,
+                            y
+                        }
+                    }
+                `
+              })
+              .then(res => {
+                // chart.data.datasets[0].data.push(...[{x: new Date(), y: 1}]);
+                const data = res.data.ksqlDBMetrics.map((queryObj) => {
+                    return {
+                        x: new Date(queryObj.x * 1000),
+                        y: queryObj.y
+                    }
+                });
+                chart.data.datasets[0].data = data;
+              })
+              .catch(error => console.log(error));
+            }
+          }
+        },
+        y: {
+            beginAtZero: true,
+            ticks: {
+                // display: false,
+                color: "#999",
+                stepSize: 5
+            }
+        }
+      },
+      plugins: {
+        legend: {
+            display: false,
+        //   position: "top",
+        },
+        title: {
+          fontFamily: 'Raleway',
+          color: '#666',
+          display: true,
+          text: description,
+        },
+      },
+    }
+  };
+
+  // instantiate new instance of a chart
+  const realTimeChart = new Chart(ctx, config);
+
+  // populate initial data to avoid having to wait for first refresh
+  // client.query({
+  //   query: gql`
+  //       query testQuery {
+  //         ksqlDBMetrics(metric: "numActiveQueries", resolution: 1, start: ${Math.round(new Date().getTime() / 1000) - 500}, end: ${Math.round(new Date().getTime() / 1000)}) {
+  //               x,
+  //               y
+  //           }
+  //       }
+  //   `
+  // })
+  // .then(res => {
+  //   // chart.data.datasets[0].data.push(...[{x: new Date(), y: 1}]);
+  //   const data = res.data.ksqlDBMetrics.map((queryObj) => {
+  //       return {
+  //           x: new Date(queryObj.x * 1000),
+  //           y: queryObj.y
+  //       }
+  //   });
+  //   console.log('this is a test');
+  //   realTimeChart.data.datasets[0].data = data;
+  //   realTimeChart.update();
+  // })
+  // .catch(error => console.log(error));
+
+
+    // chart teardown on unmount
+    return () => {
+        realTimeChart.destroy();
+    }
+  }, []);
+
+  return (
+    <Grid item xs={2}>
+      <canvas id={metric} width="100%" height="100%"></canvas>
+    </Grid>
+  );
+}


### PR DESCRIPTION
Implemented real-time line chart component that displays metrics scraped from ksqlDB via Prometheus API. 

Steps in order to have components display metrics:

1. spin up all test containers (run 'docker-comose up' within the 'ksqLight' subrepository)
2. run graphQL server (npm run devServer)
3. spin up electron app (npm run electron:serve)

![image](https://user-images.githubusercontent.com/92692816/180365164-6237a618-a96b-43cd-b7de-34e704b87e9a.png)
