### PR TITLE
Allow for installation

### DIFF
--- a/ksQlient/package.json
+++ b/ksQlient/package.json
@@ -2,7 +2,7 @@
   "name": "ksqlient",
   "version": "1.0.1",
   "description": "Javascript KsqlDB client for Node.js",
-  "main": "./ksQlient/ksqldb",
+  "main": "./ksqldb/ksqldb",
   "scripts": {
     "test": "jest --verbose --forceExit"
   },


### PR DESCRIPTION
So I wanted to use ksQlient (1.0.1) on nodejs 18.14, but stumbled upon the following error:
```
node:internal/modules/cjs/loader:361
      throw err;
      ^

Error: Cannot find module '/Users/me/GP-pi-code/testproducer/node_modules/ksqlient/ksqldb'. Please verify that the package.json has a valid "main" entry
    at tryPackage (node:internal/modules/cjs/loader:353:19)
    at Function.Module._findPath (node:internal/modules/cjs/loader:566:18)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:919:27)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/Users/me/GP-pi-code/testproducer/produce.js:2:16)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1155:10)
    at Module.load (node:internal/modules/cjs/loader:981:32) {
  code: 'MODULE_NOT_FOUND',
  path: '/Users/me/GP-pi-code/testproducer/node_modules/ksqlient/package.json',
  requestPath: 'ksqlient'
}
```

For this snippet: 
```js
const ksqldb = require("ksqlient");
const client = new ksqldb({ ksqldbURL: "http://localhost:8088" });

(async () => {
    const respones = await client.pull("SELECT * FROM WHITELIST;");
    console.log(respones);
})().catch(e => {
    console.log(e);
});
```

The tests are still passing and now I do get a successful response in my code.
<img width="703" alt="Schermafbeelding 2023-05-19 om 16 09 34" src="https://github.com/oslabs-beta/ksqlSuite/assets/43108191/3943eba0-f3bc-47fe-b9cd-7d059d54c341">
